### PR TITLE
Update package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-oc",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "grunt wrapper for oc cli",
   "main": "Gruntfile.js",
   "scripts": {


### PR DESCRIPTION
in order to use 0.37 version of oc (otherwise it breaks if you try to user url) - which was introduced by #28